### PR TITLE
feat: add address fields to admin and registration email

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -216,6 +216,20 @@ class PersonAdmin(admin.ModelAdmin):
             {"fields": ("can_book_schulungen",)},
         ),
         (
+            "Registrierungsinformationen",
+            {
+                "fields": (
+                    "firmenname",
+                    "firmenanschrift",
+                    "adresse",
+                    "plz",
+                    "ort",
+                ),
+                "classes": ("collapse",),
+                "description": "Bei der Registrierung erfasste Adressinformationen",
+            },
+        ),
+        (
             "Sonstige",
             {"fields": ("dsv_akzeptiert",), "classes": ("collapse",)},
         ),

--- a/core/templates/emails/admin_registration_notification.html
+++ b/core/templates/emails/admin_registration_notification.html
@@ -70,6 +70,17 @@
                 {% if person.telefon %}
                 <p><strong>Telefon:</strong> {{ person.telefon }}</p>
                 {% endif %}
+                {% if person.firmenname %}
+                <p><strong>Firmenname:</strong> {{ person.firmenname }}</p>
+                {% endif %}
+                {% if person.firmenanschrift %}
+                <p><strong>Firmenanschrift:</strong> {{ person.firmenanschrift }}</p>
+                {% endif %}
+                {% if person.adresse or person.plz or person.ort %}
+                <p><strong>Privatadresse:</strong>
+                    {% if person.adresse %}{{ person.adresse }}{% endif %}{% if person.plz %}, {{ person.plz }}{% endif %}{% if person.ort %} {{ person.ort }}{% endif %}
+                </p>
+                {% endif %}
                 <p><strong>Registriert am:</strong> {{ person.activation_requested_at|date:"d.m.Y H:i" }}</p>
                 <p><strong>Datenschutz akzeptiert:</strong> {% if person.dsv_akzeptiert %}Ja{% else %}Nein{% endif %}</p>
             </div>


### PR DESCRIPTION
- Add collapsed "Registrierungsinformationen" section in Person admin showing company and personal address fields
- Include company name, company address, and personal address in admin registration notification email
- Fields are displayed conditionally when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)